### PR TITLE
[BOc] Integrate go_router library

### DIFF
--- a/lib/config/router/app_router.dart
+++ b/lib/config/router/app_router.dart
@@ -1,0 +1,16 @@
+import 'package:financiera_milenians_app/presentation/screen/screens.dart';
+import 'package:go_router/go_router.dart';
+
+final appRouter = GoRouter(
+  initialLocation: '/',
+  routes: [
+    GoRoute(
+      path: '/',
+      builder: (context, state) => const MainScreen(),
+    ),
+    GoRoute(
+      path: '/register_card',
+      builder: (context, state) => const RegisterCardScreen(),
+    )
+  ]
+);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,6 @@
-import 'package:financiera_milenians_app/presentation/screen/screens.dart';
 import 'package:flutter/material.dart';
 
+import 'package:financiera_milenians_app/config/router/app_router.dart';
 import 'package:financiera_milenians_app/config/theme/app_theme.dart';
 
 void main() {
@@ -12,10 +12,10 @@ class MainApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return MaterialApp.router(
       debugShowCheckedModeBanner: false,
+      routerConfig: appRouter,
       theme: AppTheme().getTheme(),
-      home: const MainScreen(),
     );
   }
 }

--- a/lib/presentation/screen/cards_screen.dart
+++ b/lib/presentation/screen/cards_screen.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/material.dart';
 
+import 'package:go_router/go_router.dart';
+
 class CardsScreen extends StatelessWidget {
   const CardsScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      body: SafeArea(
+    return Scaffold(
+      body: const SafeArea(
         child: Center(
           child: Column(
             children: [
@@ -15,6 +17,15 @@ class CardsScreen extends StatelessWidget {
             ],
           ),
         ),
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        backgroundColor: Colors.blue,
+        onPressed: () => context.push('/register_card'),
+        label: const Text(
+          'Agregar',
+          style: TextStyle(color: Colors.white),
+        ),
+        icon: const Icon(Icons.add, color: Colors.white),
       ),
     );
   }

--- a/lib/presentation/screen/main_screen.dart
+++ b/lib/presentation/screen/main_screen.dart
@@ -2,8 +2,8 @@ import 'package:financiera_milenians_app/presentation/screen/screens.dart';
 import 'package:flutter/material.dart';
 
 class MainScreen extends StatefulWidget {
-  static const String nameProfitTab = 'Profit';
   static const String nameCardsTab = 'Cards';
+  static const String nameProfitTab = 'Profit';
   
   const MainScreen({super.key});
 
@@ -15,8 +15,8 @@ class _MainScreenState extends State<MainScreen> {
   int selectedIndex = 0;
 
   final Map<String, IconData> mapBottomNavigationData = {
-    MainScreen.nameProfitTab: Icons.savings,
     MainScreen.nameCardsTab: Icons.credit_card,
+    MainScreen.nameProfitTab: Icons.savings,
   };
 
   @override
@@ -26,8 +26,8 @@ class _MainScreenState extends State<MainScreen> {
         child: IndexedStack(
           index: selectedIndex,
           children: const [
-            ProfitScreen(),
             CardsScreen(),
+            ProfitScreen(),
           ],
         ),
       ),

--- a/lib/presentation/screen/register_card_screen.dart
+++ b/lib/presentation/screen/register_card_screen.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+
+import 'package:go_router/go_router.dart';
+
+import 'package:financiera_milenians_app/presentation/widget/textfields.dart';
+
+class RegisterCardScreen extends StatelessWidget {
+  const RegisterCardScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    const colorWhite = Colors.white;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Agregar tarjeta'),
+        leading: IconButton(
+          onPressed: () => context.pop(),
+          icon: const Icon(Icons.arrow_back, color: Colors.black),
+        ),
+      ),
+      body: const Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SimpleTextField(hinttext: 'Ingresa un alias a la tarjeta'),
+          SimpleTextField(hinttext: 'Ingresa el nombre del dueño'),
+          SimpleTextField(hinttext: 'Ingresa el banco de la tarjeta'),
+          SimpleTextField(hinttext: 'Ingresa el número de la tarjeta'),
+        ],
+      ),
+      floatingActionButton: FloatingActionButton.extended(
+        backgroundColor: Colors.blue,
+        onPressed: () {},
+        label: const Text(
+          'Guardar',
+          style: TextStyle(color: colorWhite),
+        ),
+        icon: const Icon(Icons.save_as_outlined, color: colorWhite),
+      ),
+    );
+  }
+}

--- a/lib/presentation/screen/screens.dart
+++ b/lib/presentation/screen/screens.dart
@@ -1,3 +1,4 @@
 export 'cards_screen.dart';
 export 'main_screen.dart';
 export 'profit_screen.dart';
+export 'register_card_screen.dart';

--- a/lib/presentation/widget/simple_text_field.dart
+++ b/lib/presentation/widget/simple_text_field.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+class SimpleTextField extends StatelessWidget {
+  final String hinttext;
+
+  const SimpleTextField({
+    super.key,
+    required this.hinttext,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+      child: TextField(
+        decoration: InputDecoration(
+          border: const OutlineInputBorder(),
+          hintText: hinttext,
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/widget/textfields.dart
+++ b/lib/presentation/widget/textfields.dart
@@ -1,0 +1,1 @@
+export 'simple_text_field.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,7 @@ dependencies:
   equatable: ^2.0.5
   flutter_bloc: ^8.1.3
   intl: ^0.19.0
+  go_router: ^14.6.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Description
**go_router** library is added. This allow to navigate between screens and closes it.

### Step by step
- Add go_router library.
- Create **GoRouter** variable, this to manage the screens with the path.
- You _MaterialApp_ should be to init with _MaterialApp.router_ function, this allow to init with a _RouterConfig_.

### Key fragments code

Create GoRouter variable.

``` dart
final appRouter = GoRouter(
  initialLocation: '/',
  routes: [
    GoRoute(
      path: '/',
      builder: (context, state) => const MainScreen(),
    ),
  ]
);
```

How to navigate to a screen?
``` dart
context.push('/register_card')
```

How to navigate to previous screen?
``` dart
context.pop()
```

### Evidence

https://github.com/user-attachments/assets/07e4a76e-ef59-405b-a8e8-897efdeeb89d


### Notes
- For install **go_router** library check this [link](https://pub.dev/packages/go_router/install).
